### PR TITLE
add path prefix optional parameter for login url

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -2,10 +2,10 @@ import createUUID from './createUUID';
 
 Cypress.Commands.add(
   'login',
-  ({ root, realm, username, password, client_id, redirect_uri }) =>
+  ({ root, realm, username, password, client_id, redirect_uri, path_prefix }) =>
     cy
       .request({
-        url: `${root}/auth/realms/${realm}/protocol/openid-connect/auth`,
+        url: `${root}/${path_prefix || 'auth' }/realms/${realm}/protocol/openid-connect/auth`,
         qs: {
           client_id,
           redirect_uri,


### PR DESCRIPTION
Our system does not use the /auth path so that needs to be configurable, otherwise the login does not work!

Thanks!