### PR TITLE
remove path prefix if undefined

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -13,7 +13,9 @@ Cypress.Commands.add(
   }) =>
     cy
       .request({
-        url: `${root}/${path_prefix}/realms/${realm}/protocol/openid-connect/auth`,
+        url: `${root}${
+          path_prefix ? `/${path_prefix}` : ''
+        }/realms/${realm}/protocol/openid-connect/auth`,
         qs: {
           client_id,
           redirect_uri,


### PR DESCRIPTION
If we specify path_prefix as `undefined`, then it will remove the path prefix from the url instead of showing `<root>//realms`.