### PR TITLE
Allow to specify the path prefix within the logout, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Two `cy` commands have been added:
   - `root`: string
   - `realm`: string
   - `redirect_uri`: string
+  - `path_prefix`?: string = "auth"
 - **`cy.login({ ... })`**:
   - `root`: string
   - `realm`: string

--- a/src/logout.ts
+++ b/src/logout.ts
@@ -1,6 +1,6 @@
-Cypress.Commands.add('logout', ({ root, realm, redirect_uri }) =>
+Cypress.Commands.add('logout', ({ root, realm, redirect_uri, path_prefix = 'auth' }) =>
   cy.request({
     qs: { redirect_uri },
-    url: `${root}/auth/realms/${realm}/protocol/openid-connect/logout`,
+    url: `${root}${ path_prefix ? `/${path_prefix}` : ''}/realms/${realm}/protocol/openid-connect/logout`,
   })
 );


### PR DESCRIPTION
Using the logout command with a path different from auth does not work.
I've just adepeted the part from the login command, so hope it fits