### PR TITLE
chore: support cypress 7, 8 and 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src/"
   },
   "peerDependencies": {
-    "cypress": "^6.5.0"
+    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0"
   },
   "types": "src/index.d.ts",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src/"
   },
   "peerDependencies": {
-    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0"
+    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "types": "src/index.d.ts",
   "devDependencies": {


### PR DESCRIPTION
`yarn install` currently outputs the following warning:
```
warning " > cypress-keycloak@1.7.0" has incorrect peer dependency "cypress@^6.5.0".
```

we used the plugin with cypress 7 and 8 and it works perfectly fine :)