### PR TITLE
Add S256 PKCE Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "MIT",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": "babangsund",
   "main": "dist/index.js",
   "name": "cypress-keycloak",
@@ -30,5 +30,9 @@
     "rollup-plugin-terser": "^6.1.0",
     "rollup-plugin-typescript": "^1.0.1",
     "typescript": "^3.7.4"
+  },
+  "dependencies": {
+    "base64-js": "^1.5.1",
+    "js-sha256": "^0.9.0"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,6 +14,7 @@ declare namespace Cypress {
     client_id: string;
     path_prefix?: string;
     redirect_uri: string;
+    code_challenge_method?: string;
   }
   interface LoginOTP extends Login {
     otp_secret: string;
@@ -28,6 +29,7 @@ declare namespace Cypress {
       password,
       client_id,
       redirect_uri,
+      code_challenge_method,
     }: Login): Chainable;
     loginOTP({
       root,

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,21 +1,68 @@
 import createUUID from './createUUID';
+function generateCodeVerifier(len: number): string {
+  return generateRandomString(len, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789');
+}
+
+import { sha256 as jssha256 } from 'js-sha256';
+import * as base64js from 'base64-js';
+
+function generateRandomData(len: number): Uint8Array | number[] {
+  // use web crypto APIs if possible
+  let array = null;
+  const crypto = window.crypto;
+  if (crypto && crypto.getRandomValues && window.Uint8Array) {
+    array = new Uint8Array(len);
+    crypto.getRandomValues(array);
+    return array;
+  }
+
+  // fallback to Math random
+  array = new Array(len);
+  for (let j = 0; j < array.length; j++) {
+    array[j] = Math.floor(256 * Math.random());
+  }
+  return array;
+}
+
+function generateRandomString(len: number, alphabet: string): string {
+  const randomData = generateRandomData(len);
+  const chars = new Array(len);
+  for (let i = 0; i < len; i++) {
+    chars[i] = alphabet.charCodeAt(randomData[i] % alphabet.length);
+  }
+  return String.fromCharCode.apply(null, chars);
+}
 
 Cypress.Commands.add(
   'login',
-  ({
+  function ({
     root,
     realm,
     username,
     password,
     client_id,
     redirect_uri,
+    code_challenge_method,
     path_prefix = 'auth',
-  }) =>
-    cy
+  }) {
+    const pkce: Record<string, string> = {};
+    if (code_challenge_method && code_challenge_method === 'S256') {
+      // only support S256 not plain, keycloak.js does not support anything else
+      pkce['code_challenge_method'] = code_challenge_method
+      // hash codeVerifier, then encode as url-safe base64 without padding
+      const code_verifier = generateCodeVerifier(96);
+      const hashBytes = new Uint8Array(jssha256.arrayBuffer(code_verifier));
+      const encodedHash = base64js.fromByteArray(hashBytes)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '');
+      pkce['code_challenge'] = encodedHash;
+      console.log(pkce);
+    }
+    return cy
       .request({
-        url: `${root}${
-          path_prefix ? `/${path_prefix}` : ''
-        }/realms/${realm}/protocol/openid-connect/auth`,
+        url: `${root}${path_prefix ? `/${path_prefix}` : ''
+          }/realms/${realm}/protocol/openid-connect/auth`,
         qs: {
           client_id,
           redirect_uri,
@@ -24,9 +71,9 @@ Cypress.Commands.add(
           nonce: createUUID(),
           response_type: 'code',
           response_mode: 'fragment',
+          ...pkce,
         },
-      })
-      .then((response) => {
+      }).then((response) => {
         const html = document.createElement('html');
         html.innerHTML = response.body;
 
@@ -45,4 +92,5 @@ Cypress.Commands.add(
             },
           });
       })
+  }
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,6 +351,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -563,10 +568,10 @@ cypress-otp@^1.0.3:
   dependencies:
     otplib "12.0.1"
 
-cypress@6.6:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.6.0.tgz#659c64cdb06e51b6be18fdac39d8f192deb54fa0"
-  integrity sha512-+Xx3Zn653LJHUsCb9h1Keql2jlazbr1ROmbY6DFJMmXKLgXP4ez9cE403W93JNGRbZK0Tng3R/oP8mvd9XAPVg==
+cypress@^6.6:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.9.1.tgz#ce1106bfdc47f8d76381dba63f943447883f864c"
+  integrity sha512-/RVx6sOhsyTR9sd9v0BHI4tnDZAhsH9rNat7CIKCUEr5VPWxyfGH0EzK4IHhAqAH8vjFcD4U14tPiJXshoUrmQ==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
@@ -1243,6 +1248,11 @@ jest-worker@^26.0.0:
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+js-sha256@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
+  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
I'm opening this PR just to start a conversation about how to add this feature. It seems to work in my testing of FF(94), Cr(95) and Electron. It's very rough and ready and liberally takes code from the upstream keycloak repo. Their license is Apache 2.0. I am not a lawyer, so it may need a re-write to merge into an MIT project. The 2 libraries they depend upon for crypto are MIT licensed.

 - add the two missing fields, code_challenge and code_challenge_method, to make this library compatible with keycloak
   15 and PKCE S256 mode

Consider this a proof of concept and a way to demonstrate that it works.