### PR TITLE
fixing: Could not resolve dependency Cypress 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src/"
   },
   "peerDependencies": {
-    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "types": "src/index.d.ts",
   "devDependencies": {


### PR DESCRIPTION
we get these error after upgrading to cypress 10 
so I added version in the list
Will fix this issue #31 