### PR TITLE
feat: add kc_idp_hint query param

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,7 @@ declare namespace Cypress {
     client_id: string;
     path_prefix?: string;
     redirect_uri: string;
+    kc_idp_hint?: string;
   }
   interface LoginOTP extends Login {
     otp_secret: string;
@@ -31,6 +32,7 @@ declare namespace Cypress {
       password,
       client_id,
       redirect_uri,
+      kc_idp_hint,
     }: Login): Chainable;
     loginOTP({
       root,
@@ -40,6 +42,7 @@ declare namespace Cypress {
       client_id,
       redirect_uri,
       otp_secret,
+      kc_idp_hint,
     }: LoginOTP): Chainable;
   }
 }

--- a/src/login.ts
+++ b/src/login.ts
@@ -10,6 +10,7 @@ Cypress.Commands.add(
     client_id,
     redirect_uri,
     path_prefix = 'auth',
+    kc_idp_hint,
   }) =>
     cy
       .request({
@@ -19,6 +20,7 @@ Cypress.Commands.add(
         qs: {
           client_id,
           redirect_uri,
+          kc_idp_hint,
           scope: 'openid',
           state: createUUID(),
           nonce: createUUID(),

--- a/src/loginOTP.ts
+++ b/src/loginOTP.ts
@@ -12,6 +12,7 @@ Cypress.Commands.add(
     path_prefix = 'auth',
     otp_secret,
     otp_credential_id = null,
+    kc_idp_hint,
   }) =>
     cy
       .request({
@@ -19,6 +20,7 @@ Cypress.Commands.add(
         qs: {
           client_id,
           redirect_uri,
+          kc_idp_hint,
           scope: 'openid',
           state: createUUID(),
           nonce: createUUID(),


### PR DESCRIPTION
We do have an auto-redirect to a specific Identity Provider in keycloak therefore we do not get the login form by default. We'd need to use the kc_idp_hint parameter to basically disable the auto-redirect in case of e2e