### PR TITLE
feat: add registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ require('cypress-keycloak');
 
 ### Usage
 
-Two `cy` commands have been added:
+Four `cy` commands have been added:
 
 - **`cy.logout({ ... })`**:
   - `root`: string
@@ -54,6 +54,20 @@ Two `cy` commands have been added:
   - `path_prefix`?: string = "auth"
   - `otp_secret`: string
   - `otp_credential_id`?: string | null = null
+- **`cy.register({ ... })`**:
+  - `root`: string
+  - `realm`: string
+  - `client_id`: string
+  - `path_prefix`?: string = "auth"
+  - `redirect_uri`: string
+  - `kc_idp_hint`?: string
+  - `username`?: string
+  - `email`?: string
+  - `password`?: string
+  - `passwordConfirm`?: string
+  - `firstName`?: string
+  - `lastName`?: string
+  - `additionalAttributes`?: { [key: string]: any }
 
 ### Installation:
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,6 +23,21 @@ declare namespace Cypress {
     otp_secret: string;
     otp_credential_id?: string | null;
   }
+  interface Register {
+    root: string;
+    realm: string;
+    client_id: string;
+    path_prefix?: string;
+    redirect_uri: string;
+    kc_idp_hint?: string;
+    username?: string;
+    email?: string;
+    password?: string;
+    passwordConfirm?: string;
+    firstName?: string;
+    lastName?: string;
+    additionalAttributes?: { [key: string]: any };
+  }
   interface Chainable {
     logout({ root, realm, redirect_uri, post_logout_redirect_uri, id_token_hint }: Logout): Chainable;
     login({
@@ -44,5 +59,20 @@ declare namespace Cypress {
       otp_secret,
       kc_idp_hint,
     }: LoginOTP): Chainable;
+    register({
+      root,
+      realm,
+      client_id,
+      path_prefix,
+      redirect_uri,
+      kc_idp_hint,
+      username,
+      email,
+      password,
+      passwordConfirm,
+      firstName,
+      lastName,
+      additionalAttributes,
+    }: Register): Chainable;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import './login';
 import './loginOTP';
 import './logout';
+import './register';

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,0 +1,68 @@
+import createUUID from "./createUUID";
+
+Cypress.Commands.add(
+  "register",
+  ({
+    root,
+    realm,
+    client_id,
+    path_prefix = "auth",
+    redirect_uri,
+    kc_idp_hint,
+    username,
+    email,
+    password,
+    passwordConfirm,
+    firstName,
+    lastName,
+    additionalAttributes,
+  }) =>
+    cy
+      .request({
+        url: `${root}${
+          path_prefix ? `/${path_prefix}` : ""
+        }/realms/${realm}/protocol/openid-connect/registrations`,
+        qs: {
+          client_id,
+          redirect_uri,
+          kc_idp_hint,
+          scope: "openid",
+          state: createUUID(),
+          nonce: createUUID(),
+          response_type: "code",
+          response_mode: "fragment",
+        },
+      })
+      .then((response) => {
+        const html = document.createElement("html");
+        html.innerHTML = response.body;
+
+        const form = html.getElementsByTagName("form");
+        const isAuthorized = !form.length;
+
+        let body = {
+          username,
+          password,
+          passwordConfirm,
+          email,
+          firstName,
+          lastName,
+        };
+
+        for (const [key, value] of Object.entries(additionalAttributes)) {
+          body = {
+            ...body,
+            [key]: value,
+          };
+        }
+
+        if (!isAuthorized)
+          return cy.request({
+            form: true,
+            method: "POST",
+            url: form[0].action,
+            followRedirect: false,
+            body,
+          });
+      })
+);


### PR DESCRIPTION
This adds the feature to register a new user in keycloak from a cypress test:

```js
cy.register({
  root: "https://my-keycloak.com",
  realm: "myrealm",
  email: `foo@bar.com`,
  password: "super-secret",
  client_id: "my-client",
  additionalAttributes: {
    'user.attributes.birthDay': "01",
    'user.attributes.birthMonth': "01",
    'user.attributes.birthYear': "1999",
  },
})
```
