### PR TITLE
Update peer dependencies to latest Cypress version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "babangsund",
   "main": "dist/index.js",
   "name": "cypress-keycloak",
@@ -14,7 +14,7 @@
     "lint": "eslint src/"
   },
   "peerDependencies": {
-    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^12.0.0"
   },
   "types": "src/index.d.ts",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src/"
   },
   "peerDependencies": {
-    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^12.0.0"
+    "cypress": "^6.5.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
   },
   "types": "src/index.d.ts",
   "devDependencies": {


### PR DESCRIPTION
This is a simple change to fix peerDependencies issues when using this dependency with Cypress 12. @babangsund please take a look.