### PR TITLE
Add client_id param for logout

### DIFF
--- a/src/logout.ts
+++ b/src/logout.ts
@@ -6,13 +6,17 @@ Cypress.Commands.add(
     redirect_uri,
     post_logout_redirect_uri,
     id_token_hint,
+    client_id,
     path_prefix = 'auth',
   }) => {
-    const qs = post_logout_redirect_uri
-      ? { post_logout_redirect_uri, id_token_hint }
+    const qs: Record<string, string> = post_logout_redirect_uri
+      ? { post_logout_redirect_uri }
       : { redirect_uri };
     if (post_logout_redirect_uri && id_token_hint) {
       qs.id_token_hint = id_token_hint;
+    }
+    if (post_logout_redirect_uri && client_id) {
+      qs.client_id = client_id;
     }
 
     return cy


### PR DESCRIPTION
When using `post_logout_redirect_uri` either an `id_token_hint` or `client_id` is needed. This PR adds the option to use `client_id` as well.